### PR TITLE
Replace deprecated instruction `maintainer` with `label`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:stable
 
-MAINTAINER Rainist <engineering@rainist.com>
+LABEL maintainer="Rainist <engineering@rainist.com>"
 
 COPY run.sh .
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Replace `maintainer` instruction with `label` ([Reference](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated))